### PR TITLE
Add option to copy Google Drive API refresh token

### DIFF
--- a/Delta/Features/Advanced/PowerUser.swift
+++ b/Delta/Features/Advanced/PowerUser.swift
@@ -11,8 +11,23 @@ import SwiftUI
 import Features
 import DeltaCore
 
+import Harmony
+import Roxas
+
 struct PowerUserOptions
 {
+    @Option(name: "Copy Google Drive Refresh Token",
+            description: "This will copy your Google Drive refresh token if you use Ignited Sync for use in other applications. If you don't know what this is, don't share this token anywhere! It allows access to your Ignited files outside of Ignited.",
+            detailView: { _ in
+        Button("Copy Google Drive Refresh Token") {
+            copyDriveToken()
+        }
+        .font(.system(size: 17, weight: .bold, design: .default))
+        .foregroundColor(.red)
+        .displayInline()
+    })
+    var copyDriveRefreshToken: String = ""
+
     @Option(name: "Clear Auto Save States",
             description: "This will delete all auto save states from every game. The auto-load save states feature relies on these auto save states to resume your game where you left off. Deleting them can be useful to reduce the size of your Sync backup.",
             detailView: { _ in
@@ -68,7 +83,31 @@ extension PowerUserOptions
     {
         Settings.lastUpdateShown = 1
     }
-    
+
+    static func copyDriveToken()
+    {
+        guard let topViewController = UIApplication.shared.topViewController() else { return }
+
+        if SyncManager.shared.coordinator == nil {
+            let toast = RSTToastView(text: NSLocalizedString("You don't seem to have Ignited Sync enabled.", comment: ""), detailText: nil)
+            toast.show(in: topViewController.view, duration: 5.0)
+            return
+        }
+        let service = SyncManager.shared.coordinator?.service as? DriveService
+        let token = service?.refreshToken ?? "No token :("
+
+        if token == "No token :(" {
+            let toast = RSTToastView(text: NSLocalizedString("You cannot copy Dropbox tokens at this time.", comment: ""), detailText: nil)
+            toast.show(in: topViewController.view, duration: 5.0)
+            return
+        }
+
+        UIPasteboard.general.string = token
+        let toast = RSTToastView(text: NSLocalizedString("Successfully copied your Google Drive API refresh token for Ignited!", comment: ""), detailText: nil)
+        toast.show(in: topViewController.view, duration: 5.0)
+        return
+    }
+
     static func clearAutoSaveStates()
     {
         guard let topViewController = UIApplication.shared.topViewController() else { return }

--- a/Resources/Contributors.plist
+++ b/Resources/Contributors.plist
@@ -8,7 +8,7 @@
 		<key>link</key>
 		<string>https://github.com/rileytestut</string>
 		<key>linkName</key>
-		<string>github.com/rileytestut</string>
+		<string>GitHub</string>
 		<key>contributions</key>
 		<array>
 			<dict>
@@ -21,11 +21,34 @@
 	</dict>
 	<dict>
 		<key>name</key>
+		<string>nythepegasus</string>
+		<key>link</key>
+		<string>https://github.com/nythepegasus</string>
+		<key>linkName</key>
+		<string>GitHub</string>
+		<key>contributions</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>Setup xcconfig for building the project</string>
+				<key>link</key>
+				<string>https://github.com/LitRitt/Ignited/pull/30</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>Copy Google Drive Refresh Token feature</string>
+				<key>link</key>
+				<string>https://github.com/LitRitt/Ignited/pull/31</string>
+			</dict>
+		</array>
+	</dict>
+	<dict>
+		<key>name</key>
 		<string>Hayssam Keilany</string>
 		<key>link</key>
 		<string>https://github.com/icelaglace</string>
 		<key>linkName</key>
-		<string>github.com/icelaglace</string>
+		<string>GitHub</string>
 		<key>contributions</key>
 		<array>
 			<dict>
@@ -54,7 +77,7 @@
 		<key>link</key>
 		<string>https://github.com/noah978</string>
 		<key>linkName</key>
-		<string>github.com/noah978</string>
+		<string>GitHub</string>
 		<key>contributions</key>
 		<array>
 			<dict>
@@ -71,7 +94,7 @@
 		<key>link</key>
 		<string>https://github.com/ianclawson</string>
 		<key>linkName</key>
-		<string>github.com/ianclawson</string>
+		<string>GitHub</string>
 		<key>contributions</key>
 		<array>
 			<dict>


### PR DESCRIPTION
This adds an option to copy the Google Drive API refresh token in the Power Users section of Ignited's Settings