### PR TITLE
[GamesViewController] Adds support for Delta and public Game Boy UTIs

### DIFF
--- a/Ignited/Game Selection/GamesViewController.swift
+++ b/Ignited/Game Selection/GamesViewController.swift
@@ -445,6 +445,16 @@ extension GamesViewController: ImportControllerDelegate
         // .bin files (Genesis ROMs)
         documentTypes.insert("com.apple.macbinary-archive")
         
+        // Add Delta's exported UTIs in case user has Delta installed (which may override Ignited's UTI declarations)
+        documentTypes.insert("com.rileytestut.delta.game.gba")
+        documentTypes.insert("com.rileytestut.delta.game.gbc")
+        documentTypes.insert("com.rileytestut.delta.game.gb")
+
+        // Add public Game Boy ROM UTIs in case user has another app that declares them as Owner
+        documentTypes.insert("public.xgba-rom")
+        documentTypes.insert("public.xgbc-rom")
+        documentTypes.insert("public.xgb-rom")
+
         let itunesImportOption = iTunesImportOption(presentingViewController: self)
         
         let importController = ImportController(documentTypes: documentTypes)


### PR DESCRIPTION
If another app like Delta claims a file type with `Owner` as the `LSHandlerRank`, Ignited can no longer open that app from the file picker by default. This fix allows Ignited to open those files by manually adding their `UTType`s to the list of selected document types for the file picker.